### PR TITLE
Test integration of CloudWatch metrics

### DIFF
--- a/src/test/java/cloud/localstack/CWMetricsTest.java
+++ b/src/test/java/cloud/localstack/CWMetricsTest.java
@@ -65,10 +65,7 @@ public class CWMetricsTest {
 
     @Test
     public void testCWGetMetricData() {
-        final AmazonCloudWatch cw = AmazonCloudWatchClientBuilder.standard()
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("http://localhost:4582", "us-east-1"))
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("accesskey", "secretkey")))
-                .build();
+        final AmazonCloudWatch cw = TestUtils.getClientCloudWatch();
 
         Metric metric = new Metric()
                 .withNamespace("customNamespace")


### PR DESCRIPTION
Issue fixed:
#1128 Get CloudWatch MetricData fails - Error Code: 500 INTERNAL SERVER ERROR; Request ID: null