### PR TITLE
Add new path to possible docker exe locations in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ You can configure the Docker behaviour using the `@LocalstackDockerProperties` a
 
 For more details, please refer to the README of the main LocalStack repo: https://github.com/localstack/localstack
 
+> **_NOTE:_** These utilities assume docker is installed in one of the default locations (`C:\program files\docker\docker\resources\bin\docker.exe`,
+`C:\program files\docker\docker\resources\docker.exe`, `usr/local/bin/docker` or `usr/bin/docker`). If your docker executable is in a
+different location, then use the `DOCKER_LOCATION` environment variable to specify it.
+
 ### Deprecated Configurations
 
 Due to recent changes in LocalStack (e.g., exposing all services via a single edge port, `4566`), the following configuration parameters are now deprecated in the latest version:

--- a/src/main/java/cloud/localstack/LocalstackTestRunner.java
+++ b/src/main/java/cloud/localstack/LocalstackTestRunner.java
@@ -11,8 +11,8 @@ import org.junit.runners.model.InitializationError;
  * and then terminates when tests are complete.
  *
  * Having docker installed is a prerequisite for this test runner to execute.  If docker
- * is not installed in one of the default locations (C:\program files\docker\docker\resources\bin\, usr/local/bin or
- * usr/bin)
+ * is not installed in one of the default locations (C:\program files\docker\docker\resources\bin\docker.exe,
+ * C:\program files\docker\docker\resources\docker.exe, usr/local/bin/docker or usr/bin/docker)
  * then use the DOCKER_LOCATION environment variable to specify the location.
  *
  * Since ports are dynamically allocated, the external port needs to be resolved based on the default localstack port.

--- a/src/main/java/cloud/localstack/docker/DockerExe.java
+++ b/src/main/java/cloud/localstack/docker/DockerExe.java
@@ -26,6 +26,7 @@ public class DockerExe {
     private static final List<String> POSSIBLE_EXE_LOCATIONS = Arrays.asList(
             System.getenv("DOCKER_LOCATION"),
             "C:/program files/docker/docker/resources/bin/docker.exe",
+            "C:/program files/docker/docker/resources/docker.exe",
             "/usr/local/bin/docker",
             "/usr/bin/docker");
 

--- a/src/main/java/cloud/localstack/docker/LocalstackDockerExtension.java
+++ b/src/main/java/cloud/localstack/docker/LocalstackDockerExtension.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * and then terminates when tests are complete.
  *
  * Having docker installed is a prerequisite for this test runner to execute.  If docker
- * is not installed in one of the default locations (C:\program files\docker\docker\resources\bin\, usr/local/bin or
- * usr/bin)
+ * is not installed in one of the default locations (C:\program files\docker\docker\resources\bin\docker.exe,
+ * C:\program files\docker\docker\resources\docker.exe, usr/local/bin/docker or usr/bin/docker)
  * then use the DOCKER_LOCATION environment variable to specify the location.
  *
  * Since ports are dynamically allocated, the external port needs to be resolved based on the default localstack port.


### PR DESCRIPTION
This proposed PR adds the new location of docker.exe in Windows installations ("C:\Program Files\Docker\Docker\resources\docker.exe"). It would fix issue #24.

Besides, it updates some javadoc related to docker locations (adding the new supported location and including the file name in the paths... as the fullpath is required if the user needs to set the `DOCKER_LOCATION` environment variable).