### PR TITLE
Configure port binding behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You can configure the Docker behaviour using the `@LocalstackDockerProperties` a
 | `pullNewImage`              | Determines if a new image is pulled from the docker repo before the tests are run.                                           | boolean                      | `false`         |
 | `services`                  | Determines which services should be run when the localstack starts.                                                          | String[]                     | All           |
 | `imageTag`                  | Use a specific image tag for docker container                                                                                | String                       | `latest`        |
+| `portEdge`                  | Port number for the edge service, the main entry point for all API invocations                                               | String                       | `4566`        |
+| `portElasticSearch`         | Port number for the elasticsearch service                                                                                    | String                       | `4571`        |
 | `hostNameResolver`          | Used for determining the host name of the machine running the docker containers so that the containers can be addressed.     | IHostNameResolver            | `localhost`     |
 | `environmentVariableProvider` | Used for injecting environment variables into the container.                                                                 | IEnvironmentVariableProvider | Empty Map     |
 | `useSingleDockerContainer`  | Whether a singleton container should be used by all test classes.                     | boolean | `false`     |

--- a/src/main/java/cloud/localstack/Localstack.java
+++ b/src/main/java/cloud/localstack/Localstack.java
@@ -67,6 +67,8 @@ public class Localstack {
                 dockerConfiguration.isPullNewImage(),
                 dockerConfiguration.isRandomizePorts(),
                 dockerConfiguration.getImageTag(),
+                dockerConfiguration.getPortEdge(),
+                dockerConfiguration.getPortElasticSearch(),
                 dockerConfiguration.getEnvironmentVariables(),
                 dockerConfiguration.getPortMappings()
             );

--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -50,8 +50,8 @@ public class Container {
      * @param environmentVariables map of environment variables to be passed to the docker container
      */
     public static Container createLocalstackContainer(
-        String externalHostName, boolean pullNewImage, boolean randomizePorts, String imageTag,
-        Map<String, String> environmentVariables, Map<Integer, Integer> portMappings) {
+        String externalHostName, boolean pullNewImage, boolean randomizePorts, String imageTag, String portEdge,
+        String portElasticSearch,  Map<String, String> environmentVariables, Map<Integer, Integer> portMappings) {
 
         environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
         portMappings = portMappings == null ? Collections.emptyMap() : portMappings;
@@ -59,14 +59,18 @@ public class Container {
         String fullImageName = LOCALSTACK_NAME + ":" + (imageTag == null ? "latest" : imageTag);
         boolean imageExists = new ListImagesCommand().execute().contains(fullImageName);
 
+        String fullPortEdge = (portEdge == null ? LOCALSTACK_PORT_EDGE : portEdge) + ":" + LOCALSTACK_PORT_EDGE;
+        String fullPortElasticSearch = (portElasticSearch == null ? LOCALSTACK_PORT_ELASTICSEARCH : portElasticSearch)
+            + ":" + LOCALSTACK_PORT_ELASTICSEARCH;
+
         if(pullNewImage || !imageExists) {
             LOG.info("Pulling latest image...");
             new PullCommand(LOCALSTACK_NAME, imageTag).execute();
         }
 
         RunCommand runCommand = new RunCommand(LOCALSTACK_NAME, imageTag)
-            .withExposedPorts(LOCALSTACK_PORT_EDGE, randomizePorts)
-            .withExposedPorts(LOCALSTACK_PORT_ELASTICSEARCH, randomizePorts)
+            .withExposedPorts(fullPortEdge, randomizePorts)
+            .withExposedPorts(fullPortElasticSearch, randomizePorts)
             .withEnvironmentVariable(LOCALSTACK_EXTERNAL_HOSTNAME, externalHostName)
             .withEnvironmentVariable(ENV_DEBUG, ENV_DEBUG_DEFAULT)
             .withEnvironmentVariable(ENV_USE_SSL, Localstack.INSTANCE.useSSL() ? "1" : "0")

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
@@ -36,6 +36,8 @@ public class LocalstackDockerAnnotationProcessor {
             .ignoreDockerRunErrors(properties.ignoreDockerRunErrors())
             .randomizePorts(properties.randomizePorts())
             .imageTag(StringUtils.isEmpty(properties.imageTag()) ? null : properties.imageTag())
+            .portEdge(properties.portEdge())
+            .portElasticSearch(properties.portElasticSearch())
             .useSingleDockerContainer(properties.useSingleDockerContainer())
             .build();
     }

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -26,6 +26,12 @@ public class LocalstackDockerConfiguration {
     private final String imageTag;
 
     @Builder.Default
+    private final String portEdge = "4566";
+
+    @Builder.Default
+    private final String portElasticSearch = "4571";
+
+    @Builder.Default
     private final String externalHostName = "localhost";
 
     @Builder.Default

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -52,6 +52,16 @@ public @interface LocalstackDockerProperties {
     String imageTag() default "";
 
     /**
+     * Port number for the edge service, the main entry point for all API invocations
+     */
+    String portEdge() default "4566";
+
+    /**
+     * Port number for the elasticsearch service
+     */
+    String portElasticSearch() default "4571";
+
+    /**
      * Determines if the singleton container should be used by all test classes
      */
     boolean useSingleDockerContainer() default false;

--- a/src/main/java/cloud/localstack/docker/command/RunCommand.java
+++ b/src/main/java/cloud/localstack/docker/command/RunCommand.java
@@ -36,7 +36,10 @@ public class RunCommand extends Command {
     }
 
     public RunCommand withExposedPorts(String portsToExpose, boolean randomize) {
-        String portsOption = String.format("%s:%s", randomize ? "" : portsToExpose, portsToExpose );
+        String[] parts = portsToExpose.split(":");
+        String hostPort = randomize ? "" : parts.length > 1 ? parts[0] : portsToExpose;
+        String containerPort = parts.length > 1 ? parts[1] : portsToExpose;
+        String portsOption = String.format("%s:%s", hostPort, containerPort);
         addOptions("-p", portsOption);
         return this;
     }

--- a/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
+++ b/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
@@ -35,7 +35,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -53,7 +53,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithStaticPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);

--- a/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ContainerTest {
 
@@ -21,7 +22,7 @@ public class ContainerTest {
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
         Container localStackContainer = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, environmentVariables, null);
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, environmentVariables, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -32,6 +33,43 @@ public class ContainerTest {
             ArrayList<String> echoExternalEnv = buildEchoStatement(MY_PROPERTY);
             assertEquals(EXTERNAL_HOST_NAME, localStackContainer.executeCommand(echoDefaultEnv));
             assertEquals(MY_VALUE, localStackContainer.executeCommand(echoExternalEnv));
+
+            // Test Edge and ElasticSearch ports
+
+            assertEquals(4566, localStackContainer.getExternalPortFor(4566));
+            assertEquals(4571, localStackContainer.getExternalPortFor(4571));
+        }
+        finally {
+            localStackContainer.stop();
+        }
+    }
+
+    @Test
+    public void createLocalstackContainerWithCustomPorts() throws Exception {
+        Container localStackContainer = Container.createLocalstackContainer(
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, "45660", "45710", null, null);
+
+        try {
+            localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
+
+            assertEquals(45660, localStackContainer.getExternalPortFor(4566));
+            assertEquals(45710, localStackContainer.getExternalPortFor(4571));
+        }
+        finally {
+            localStackContainer.stop();
+        }
+    }
+
+    @Test
+    public void createLocalstackContainerWithRandomPorts() throws Exception {
+        Container localStackContainer = Container.createLocalstackContainer(
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, ":4566", ":4571", null, null);
+
+        try {
+            localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
+
+            assertNotEquals(4566, localStackContainer.getExternalPortFor(4566));
+            assertNotEquals(4571, localStackContainer.getExternalPortFor(4571));
         }
         finally {
             localStackContainer.stop();

--- a/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -21,7 +21,7 @@ public class ContainerTest {
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
         Container localStackContainer = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, environmentVariables, null);
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, environmentVariables, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);


### PR DESCRIPTION
Hi, 

This is a possible implementation of #31 to bind the Edge and ElasticSearch ports to a custom port using the `@LocalstackDockerProperties` annotation:

**Changes**

- Update `RunCommand#withExposedPorts` to pass ports like: `"4567"`, `":4567"` or `"9876:4567"`
- Add `portEdge` and `portElasticSearch` properties
- Add tests

**Examples**

Example of custom ports:

```java
@LocalstackDockerProperties(portEdge = "45660", portElasticSearch = "45710", services = {"dynamodb"})
// public class ...
```

Example of random ports (alternative to the deprecated `randomizePorts` property):

```java
@LocalstackDockerProperties(portEdge = ":4566", portElasticSearch = ":4571", services = {"dynamodb"})
// public class ...
```

Example of default ports (`4566` and `4571`):

```java
@LocalstackDockerProperties(services = {"dynamodb"})
// public class ...
```
