### PR TITLE
added dynamoDBAsync for awssdkv2 and unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>${aws.sdkv2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sns</artifactId>
             <version>${aws.sdkv2.version}</version>
             <scope>provided</scope>

--- a/src/main/java/cloud/localstack/awssdkv2/TestUtils.java
+++ b/src/main/java/cloud/localstack/awssdkv2/TestUtils.java
@@ -1,6 +1,7 @@
 package cloud.localstack.awssdkv2;
 
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.utils.*;
 import software.amazon.awssdk.http.*;
 import software.amazon.awssdk.services.cloudwatch.*;
@@ -27,6 +28,10 @@ public class TestUtils {
 
     public static KinesisAsyncClient getClientKinesisAsyncV2() {
         return wrapApiClientV2(KinesisAsyncClient.builder(), Localstack.INSTANCE.getEndpointKinesis()).build();
+    }
+
+    public static DynamoDbAsyncClient getClientDyanamoAsyncV2() {
+        return wrapApiClientV2(DynamoDbAsyncClient.builder(), Localstack.INSTANCE.getEndpointDynamoDB()).build();
     }
 
     public static SqsAsyncClient getClientSQSAsyncV2() {

--- a/src/test/java/cloud/localstack/awssdkv2/BasicFeaturesSDKV2Test.java
+++ b/src/test/java/cloud/localstack/awssdkv2/BasicFeaturesSDKV2Test.java
@@ -3,9 +3,13 @@ package cloud.localstack.awssdkv2;
 import cloud.localstack.Constants;
 import cloud.localstack.LocalstackTestRunner;
 
+import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
+import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.services.cloudwatch.*;
 import software.amazon.awssdk.services.cloudwatch.model.*;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
 import software.amazon.awssdk.services.kinesis.*;
 import software.amazon.awssdk.services.kinesis.model.*;
 import software.amazon.awssdk.services.s3.*;
@@ -76,6 +80,31 @@ public class BasicFeaturesSDKV2Test {
         putRecordRequest.data(payload);
         putRecordRequest.partitionKey(String.format("partitionKey-%d", 1));
         Assert.assertNotNull(kinesisClient.putRecord(putRecordRequest.build()));
+    }
+
+    @Test
+    public void testCreateDynamoDBTable() throws Exception {
+        DynamoDbAsyncClient dynamoDbAsyncClient = TestUtils.getClientDyanamoAsyncV2();
+        CreateTableRequest createTableRequest = CreateTableRequest.builder()
+                .keySchema(
+                        KeySchemaElement.builder()
+                                .keyType(KeyType.HASH)
+                                .attributeName("test")
+                                .build()
+                )
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeName("test")
+                        .attributeType(ScalarAttributeType.S)
+                        .build())
+                .provisionedThroughput(
+                        ProvisionedThroughput.builder()
+                                .readCapacityUnits(5L)
+                                .writeCapacityUnits(5L)
+                                .build())
+                .tableName("test")
+                .build();
+        CreateTableResponse response = dynamoDbAsyncClient.createTable(createTableRequest).get();
+        Assert.assertNotNull(response);
     }
 
     @Test


### PR DESCRIPTION
localstack java-util does not support **DynamoDBAsyncClient** required for KCL 2.0x

- Added **DynamoDBAsyncClient** support for localstack-java-util awssdkv2
- Unit test for the added client