### PR TITLE
improve port binding using environment variables

### DIFF
--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
@@ -36,10 +36,14 @@ public class LocalstackDockerAnnotationProcessor {
             .ignoreDockerRunErrors(properties.ignoreDockerRunErrors())
             .randomizePorts(properties.randomizePorts())
             .imageTag(StringUtils.isEmpty(properties.imageTag()) ? null : properties.imageTag())
-            .portEdge(properties.portEdge())
-            .portElasticSearch(properties.portElasticSearch())
+            .portEdge(getEnvOrDefault("LOCALSTACK_EDGE_PORT", properties.portEdge()))
+            .portElasticSearch(getEnvOrDefault("LOCALSTACK_ELASTICSEARCH_PORT", properties.portElasticSearch()))
             .useSingleDockerContainer(properties.useSingleDockerContainer())
             .build();
+    }
+
+    private String getEnvOrDefault(final String environmentVariable, final String defaultValue) {
+        return System.getenv().getOrDefault(environmentVariable, defaultValue);
     }
 
     private Map<Integer, Integer> getCustomPortMappings(final LocalstackDockerProperties properties) {

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -52,12 +52,14 @@ public @interface LocalstackDockerProperties {
     String imageTag() default "";
 
     /**
-     * Port number for the edge service, the main entry point for all API invocations
+     * Port number for the edge service, the main entry point for all API invocations. Alternatively, use the
+     * LOCALSTACK_EDGE_PORT environment variable.
      */
     String portEdge() default "4566";
 
     /**
-     * Port number for the elasticsearch service
+     * Port number for the elasticsearch service. Alternatively, use the LOCALSTACK_ELASTICSEARCH_PORT environment
+     * variable.
      */
     String portElasticSearch() default "4571";
 


### PR DESCRIPTION
Hi, 

This is an improvement of #33 that allows to use environment variables.

**Changes**

- Support `LOCALSTACK_EDGE_PORT` and `LOCALSTACK_ELASTICSEARCH_PORT` to configure port binding