### PR TITLE
#39 Add support and tests for specifying the imagename via @LocalstackDoc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ The container can be configured by using the `@LocalstackDockerProperties` annot
 ```
 ...
 import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.ServiceName;
 import cloud.localstack.TestUtils;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 
 @RunWith(LocalstackTestRunner.class)
-@LocalstackDockerProperties(services = { "s3", "sqs", "kinesis" })
+@LocalstackDockerProperties(services = { ServiceName.S3, "sqs", "kinesis" })
 public class MyCloudAppTest {
 
   @Test
@@ -70,6 +71,7 @@ You can configure the Docker behaviour using the `@LocalstackDockerProperties` a
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------------|---------------|
 | `pullNewImage`              | Determines if a new image is pulled from the docker repo before the tests are run.                                           | boolean                      | `false`         |
 | `services`                  | Determines which services should be run when the localstack starts.                                                          | String[]                     | All           |
+| `imageName`                 | Use a specific image name (organisation/repo) for docker container                                                           | String                       | `localstack/localstack`  |
 | `imageTag`                  | Use a specific image tag for docker container                                                                                | String                       | `latest`        |
 | `portEdge`                  | Port number for the edge service, the main entry point for all API invocations                                               | String                       | `4566`        |
 | `portElasticSearch`         | Port number for the elasticsearch service                                                                                    | String                       | `4571`        |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/src/main/java/cloud/localstack/Localstack.java
+++ b/src/main/java/cloud/localstack/Localstack.java
@@ -66,6 +66,7 @@ public class Localstack {
                 dockerConfiguration.getExternalHostName(),
                 dockerConfiguration.isPullNewImage(),
                 dockerConfiguration.isRandomizePorts(),
+                dockerConfiguration.getImageName(),
                 dockerConfiguration.getImageTag(),
                 dockerConfiguration.getPortEdge(),
                 dockerConfiguration.getPortElasticSearch(),

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
@@ -35,6 +35,7 @@ public class LocalstackDockerAnnotationProcessor {
             .pullNewImage(properties.pullNewImage())
             .ignoreDockerRunErrors(properties.ignoreDockerRunErrors())
             .randomizePorts(properties.randomizePorts())
+            .imageName(StringUtils.isEmpty(properties.imageName()) ? null : properties.imageName())
             .imageTag(StringUtils.isEmpty(properties.imageTag()) ? null : properties.imageTag())
             .portEdge(getEnvOrDefault("LOCALSTACK_EDGE_PORT", properties.portEdge()))
             .portElasticSearch(getEnvOrDefault("LOCALSTACK_ELASTICSEARCH_PORT", properties.portElasticSearch()))

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -23,6 +23,7 @@ public class LocalstackDockerConfiguration {
 
     private final boolean randomizePorts;
 
+    private final String imageName;
     private final String imageTag;
 
     @Builder.Default

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -47,6 +47,11 @@ public @interface LocalstackDockerProperties {
     String[] services() default {};
 
     /**
+     * Use a specific image name (consisting of organisation and repository, e.g. localstack/localstack-full for docker container
+     */
+    String imageName() default "";
+
+    /**
      * Use a specific image tag for docker container
      */
     String imageTag() default "";

--- a/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
+++ b/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
@@ -35,7 +35,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -53,7 +53,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithStaticPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);


### PR DESCRIPTION
Hi @whummer,

here's my PR for Issue #39.
I didn't find contribution guidelines in this repo or the localstack/localstack repo, so I hope I did everything to make your life as easy as possible - I took the 'Does it blend approach' and wrote the code similiar to the existing code and also tried to keep changes to a minimum.
I assumed that Container#createLocalstackContainer is not part of the "API" thus I did not introduce a backwards compatible method there (which would be easy to do, but by the looks of the class this has not been done in the past. On the other hand I assumed that LocalStackDockerProperties and LocalstackDockerConfiguration are the API - thus kept the changes backwards compatible there.
The only other thing I think might be worth mentioning is that I exposed the container ID of Container - to allow for the tests I wrote - to package visibility.
Looking forward to getting your feedback (or merging :) ).
Best, Chris