### PR TITLE
Add support and tests for specifying bind mounts via @LocalstackDocke…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ You can configure the Docker behaviour using the `@LocalstackDockerProperties` a
 | `portEdge`                  | Port number for the edge service, the main entry point for all API invocations                                               | String                       | `4566`        |
 | `portElasticSearch`         | Port number for the elasticsearch service                                                                                    | String                       | `4571`        |
 | `hostNameResolver`          | Used for determining the host name of the machine running the docker containers so that the containers can be addressed.     | IHostNameResolver            | `localhost`     |
-| `environmentVariableProvider` | Used for injecting environment variables into the container.                                                                 | IEnvironmentVariableProvider | Empty Map     |
-| `useSingleDockerContainer`  | Whether a singleton container should be used by all test classes.                     | boolean | `false`     |
+| `environmentVariableProvider` | Used for injecting environment variables into the container.                                                               | IEnvironmentVariableProvider | Empty Map     |
+| `bindMountProvider          | Used bind mounting files and directories into the container, useful to run init scripts before using the container.          | IBindMountProvider           | Empty Map     |
+|  initializationToken        | Give a regex that will be searched in the logstream of the container, start is complete only when the token is found. Use with bindMountProvider to execute init scripts. | String | Empty String |
+| `useSingleDockerContainer`  | Whether a singleton container should be used by all test classes.                                                            | boolean | `false`     |
 
 For more details, please refer to the README of the main LocalStack repo: https://github.com/localstack/localstack
 

--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -51,12 +51,17 @@ public class Container {
      * @param imageName the name of the image defaults to {@value LOCALSTACK_NAME} if null
      * @param imageTag the tag of the image to pull, defaults to {@value LOCALSTACK_TAG} if null
      * @param environmentVariables map of environment variables to be passed to the docker container
+     * @param portMappings
+     * @param bindMounts  Docker host to container volume mapping like /host/dir:/container/dir, be aware that the host
+     * directory must be an absolute path
      */
     public static Container createLocalstackContainer(
-        String externalHostName, boolean pullNewImage, boolean randomizePorts, String imageName, String imageTag, String portEdge,
-        String portElasticSearch,  Map<String, String> environmentVariables, Map<Integer, Integer> portMappings) {
+            String externalHostName, boolean pullNewImage, boolean randomizePorts, String imageName, String imageTag, String portEdge,
+            String portElasticSearch, Map<String, String> environmentVariables, Map<Integer, Integer> portMappings,
+            Map<String, String> bindMounts) {
 
         environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
+        bindMounts = bindMounts == null ? Collections.emptyMap() : bindMounts;
         portMappings = portMappings == null ? Collections.emptyMap() : portMappings;
 
         String imageNameOrDefault = (imageName == null ? LOCALSTACK_NAME : imageName);
@@ -78,7 +83,9 @@ public class Container {
             .withEnvironmentVariable(LOCALSTACK_EXTERNAL_HOSTNAME, externalHostName)
             .withEnvironmentVariable(ENV_DEBUG, ENV_DEBUG_DEFAULT)
             .withEnvironmentVariable(ENV_USE_SSL, Localstack.INSTANCE.useSSL() ? "1" : "0")
-            .withEnvironmentVariables(environmentVariables);
+            .withEnvironmentVariables(environmentVariables)
+            .withBindMountedVolumes(bindMounts);
+
         for (Integer port : portMappings.keySet()) {
             runCommand = runCommand.withExposedPorts("" + port, false);
         }

--- a/src/main/java/cloud/localstack/docker/annotation/IBindMountProvider.java
+++ b/src/main/java/cloud/localstack/docker/annotation/IBindMountProvider.java
@@ -1,0 +1,34 @@
+package cloud.localstack.docker.annotation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+public interface IBindMountProvider extends Supplier<Map<String, String>> {
+
+    class EmptyBindMountProvider implements IBindMountProvider {
+
+        @Override
+        public Map<String, String> get() {
+            return Collections.emptyMap();
+        }
+    }
+
+    abstract class BaseBindMountProvider implements IBindMountProvider {
+
+        private Map<String, String> mounts = new HashMap<>();
+
+        protected BaseBindMountProvider() {
+            initValues(mounts);
+        }
+
+        protected abstract void initValues(Map<String, String> mounts);
+
+        @Override
+        public final Map<String, String> get() {
+            return mounts;
+        }
+    }
+}

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -5,6 +5,8 @@ import lombok.Data;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.regex.Pattern;
+
 
 /**
  * Bean to specify the docker configuration.
@@ -40,6 +42,11 @@ public class LocalstackDockerConfiguration {
 
     @Builder.Default
     private final Map<Integer, Integer> portMappings = Collections.emptyMap();
+
+    @Builder.Default
+    private final Map<String, String> bindMounts = Collections.emptyMap();
+
+    private final Pattern initializationToken;
 
     @Builder.Default
     private final boolean useSingleDockerContainer = false;

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -1,10 +1,11 @@
 package cloud.localstack.docker.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.Inherited;
+
 
 /**
  * An annotation to provide parameters to the main (Docker-based) LocalstackTestRunner
@@ -27,6 +28,18 @@ public @interface LocalstackDockerProperties {
     Class<? extends IEnvironmentVariableProvider> environmentVariableProvider() default DefaultEnvironmentVariableProvider.class;
 
     /**
+     * Used for injecting directories or files that are bind mounted into the docker container. Implement a class that provides a map
+     * of host to container directory or file mappings, with host directories/files as keys and container directories/files as values.
+     * Remember that Docker needs absolute paths for host directories and files.
+     */
+    Class<? extends IBindMountProvider> bindMountProvider() default IBindMountProvider.EmptyBindMountProvider.class;
+
+    /**
+     * A Java Regex that is used to wait for the execution of custom init scripts 
+     */
+    String initializationToken() default "";
+
+    /**
      * Determines if a new image is pulled from the docker repo before the tests are run.
      */
     boolean pullNewImage() default false;
@@ -43,6 +56,7 @@ public @interface LocalstackDockerProperties {
     /**
      * Determines which services should be run when the localstack starts. When empty, all the services available get
      * up and running.
+     * @see cloud.localstack.ServiceName
      */
     String[] services() default {};
 

--- a/src/main/java/cloud/localstack/docker/command/RunCommand.java
+++ b/src/main/java/cloud/localstack/docker/command/RunCommand.java
@@ -44,6 +44,11 @@ public class RunCommand extends Command {
         return this;
     }
 
+    public RunCommand withBindMountedVolumes(Map<String, String> hostToContainerMappings) {
+        hostToContainerMappings.forEach((host, container) -> addOptions("-v", String.format("%s:%s", host, container)));
+        return this;
+    }
+
     public RunCommand withEnvironmentVariable(String name, String value) {
         addEnvOption(name, value);
         return this;

--- a/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
+++ b/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
@@ -6,16 +6,16 @@ import cloud.localstack.awssdkv1.TestUtils;
 import cloud.localstack.docker.Container;
 import cloud.localstack.docker.LocalstackDockerExtension;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
-
+import com.amazonaws.services.sqs.AmazonSQS;
+import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
-import org.junit.Test;
 
-import static org.junit.Assert.*;
-
-import com.amazonaws.services.sqs.AmazonSQS;
-
-import static cloud.localstack.docker.ContainerTest.*;
+import static cloud.localstack.docker.ContainerTest.EXTERNAL_HOST_NAME;
+import static cloud.localstack.docker.ContainerTest.pullNewImage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(LocalstackTestRunner.class)
 @ExtendWith(LocalstackDockerExtension.class)
@@ -35,7 +35,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -53,7 +53,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithStaticPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);

--- a/src/test/java/cloud/localstack/docker/LocalstackDockerPropertiesWithBindMountTest.java
+++ b/src/test/java/cloud/localstack/docker/LocalstackDockerPropertiesWithBindMountTest.java
@@ -1,0 +1,38 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.Localstack;
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.docker.annotation.IBindMountProvider;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(LocalstackTestRunner.class)
+@ExtendWith(LocalstackDockerExtension.class)
+@LocalstackDockerProperties(bindMountProvider = LocalstackDockerPropertiesWithBindMountTest.TestMounts.class,
+    initializationToken = "testmarker")
+public class LocalstackDockerPropertiesWithBindMountTest {
+
+    @Test
+    @org.junit.jupiter.api.Test
+    public void bindMound() {
+        assertEquals("echo testmarker", Localstack.INSTANCE.getLocalStackContainer()
+                .executeCommand(Arrays.asList("cat", Localstack.INIT_SCRIPTS_PATH + "/02-init-script-test.sh")));
+    }
+
+    public static class TestMounts extends IBindMountProvider.BaseBindMountProvider {
+
+        @Override
+        protected void initValues(Map<String, String> mounts) {
+            mounts.put(new File("./src/test/resources/01-init-script-test.sh").getAbsolutePath(), Localstack.INIT_SCRIPTS_PATH + "/01-init-script-test.sh");
+            mounts.put(ContainerTest.testFile("echo testmarker"), Localstack.INIT_SCRIPTS_PATH + "/02-init-script-test.sh");
+        }
+    }
+}

--- a/src/test/java/cloud/localstack/docker/LocalstackDockerPropertiesWithImageNameTest.java
+++ b/src/test/java/cloud/localstack/docker/LocalstackDockerPropertiesWithImageNameTest.java
@@ -1,0 +1,28 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.Localstack;
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(LocalstackTestRunner.class)
+@ExtendWith(LocalstackDockerExtension.class)
+@LocalstackDockerProperties(imageName = "localstack/localstack-full")
+public class LocalstackDockerPropertiesWithImageNameTest {
+
+    @Test
+    @org.junit.jupiter.api.Test
+    public void imageName() {
+        String imageName = new DockerExe()
+                .execute(Arrays.asList("container", "inspect",
+                        Localstack.INSTANCE.getLocalStackContainer().getContainerId(),
+                        "--format", "{{.Config.Image}}"));
+        assertEquals("localstack/localstack-full", imageName);
+    }
+}

--- a/src/test/resources/01-init-script-test.sh
+++ b/src/test/resources/01-init-script-test.sh
@@ -1,0 +1,3 @@
+echo "Executing 01-init-script-test.sh"
+
+awslocal s3 mb s3://testbucket


### PR DESCRIPTION
…rProperties, LocalstackDockerConfiguration and Container#createLocalstackContainer, also added support for defining initialization token to wait for the completed execution of init scripts

Same as last pull request, tried to blend in and not change anything unnecessarily. Basically this passes the host to container strings to the container command with -v. Complexity is with the user to get it right, but it is also very flexible (using different paths, mounting keys).