### PR TITLE
Get 100 log lines

### DIFF
--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -29,7 +29,7 @@ public class Container {
     private static final int MAX_PORT_CONNECTION_ATTEMPTS = 10;
     private static final int MAX_LOG_COLLECTION_ATTEMPTS = 120;
     private static final long POLL_INTERVAL = 1000;
-    private static final int NUM_LOG_LINES = 10;
+    private static final int NUM_LOG_LINES = 100;
 
     private static final String ENV_DEBUG = "DEBUG";
     private static final String ENV_USE_SSL = "USE_SSL";


### PR DESCRIPTION
The fetched number of log lines (10) was too low s.t. when a container
took some time to boot the 404 messages from the request already took up
too much space in the logs, and the `Ready.` token could not be
detected.
This commit increases the number of log lines to 100, so that this error
should be alleviated, although it is of course not an optimal solution.

It might make sense too simply fetch all logs (with a `-1` parameter to `--tail`), and
let the user overwrite this value.

Closes #63 