### PR TITLE
consider windows EOL when listing images

### DIFF
--- a/src/main/java/cloud/localstack/docker/command/ListImagesCommand.java
+++ b/src/main/java/cloud/localstack/docker/command/ListImagesCommand.java
@@ -6,6 +6,6 @@ public class ListImagesCommand extends Command {
 
     public List<String> execute() {
         List<String> params = Arrays.asList("images", "--format", "{{.Repository}}:{{.Tag}}");
-        return Arrays.asList(dockerExe.execute(params).split("\n"));
+        return Arrays.asList(dockerExe.execute(params).replaceAll("\r", "").split("\n"));
     }
 }


### PR DESCRIPTION
This PR makes sure to remove the "\r" from the command results when listing the docker images. 
Addresses #61 