### PR TITLE
Revert removal of EC2HostNameResolver annotation

### DIFF
--- a/src/main/java/cloud/localstack/docker/annotation/EC2HostNameResolver.java
+++ b/src/main/java/cloud/localstack/docker/annotation/EC2HostNameResolver.java
@@ -1,0 +1,23 @@
+package cloud.localstack.docker.annotation;
+
+import com.amazonaws.util.EC2MetadataUtils;
+
+/**
+ * Finds the hostname of the current EC2 instance
+ *
+ * This is useful for a CI server that is itself a docker container and which mounts the docker unix socket
+ * from the host machine.  In that case, the server cannot spawn child containers but will instead spawn sibling
+ * containers which cannot be addressed at "localhost".  In order to address the sibling containers you need to resolve
+ * the hostname of the host machine, which this method will accomplish.
+ *
+ * For more information about running docker for CI and mounting the host socket please look here:
+ * http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
+ */
+public class EC2HostNameResolver implements IHostNameResolver {
+
+    @Override
+    public String getHostName() {
+        return EC2MetadataUtils.getLocalHostName();
+    }
+
+}


### PR DESCRIPTION
This annotation was removed in 7e8c8228e85fada76554bc7473679e4da76ab472
but is still useful for us and likely others that have CICD setups that
require it for our test runs.

If merged it would fix: https://github.com/localstack/localstack-java-utils/issues/73