### PR TITLE
Filter synthetic bridge methods during method detection for java lambda full handler syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.2.16</version>
+    <version>0.2.17</version>
 </dependency>
 ```
 
@@ -108,6 +108,7 @@ make build
 
 ## Change Log
 
+* v0.2.17: Fix issue with using :: to specify lambda handler which implements the RequestHandler interface, revert removal of EC2HostNameResolver annotation
 * v0.2.16: Add support for :: notation for Java Lambda handler specification, fix failing QLDB tests, fix failing tests with Jexter rules/extensions
 * v0.2.15: Fix Kinesis CBOR tests; fix project setup and classpath for SDK v1/v2 utils; fix awaiting results in tests using async clients; refactor classpath setup for v1/v2 SDKs; fall back to using edge port if port mapping cannot be determined from container
 * v0.2.14: Add ability to get handler class name through `_HANDLER` environment variable like on real AWS and Lambci environment

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.16</version>
+    <version>0.2.17</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -143,10 +143,10 @@ public class LambdaExecutor {
 	 */
 	private static Method getHandlerMethodByName(Object handler, String handlerMethodName) throws MultipleMatchingHandlersException, NoMatchingHandlerException {
 		List<Method> handlerMethods = Arrays.stream(handler.getClass().getMethods())
-				.filter(method -> method.getName().equals(handlerMethodName))
+				.filter(method -> method.getName().equals(handlerMethodName) && !method.isBridge()) // we do not want bridge methods here
 				.collect(Collectors.toList());
 		if (handlerMethods.size() > 1) {
-			throw new MultipleMatchingHandlersException("Multiple matching headers: " + handlerMethods);
+			throw new MultipleMatchingHandlersException("Multiple matching handlers: " + handlerMethods);
 		} else if (handlerMethods.isEmpty()) {
 			throw new NoMatchingHandlerException("No matching handlers for method name: "
 					+ handlerMethodName);


### PR DESCRIPTION
This PR filters the methods matched by the handler method specification, so matching bridge methods do not get invoked / counted.
This is necessary for invoking methods which are also part of the implementation of a generic interface, like implementing RequestHandler, and then specifying the method handleRequest in the handler specification.

Should (finally) fix https://github.com/localstack/localstack/issues/4512

Test for this behavior will be published in a complementing LocalStack PR.