### PR TITLE
Add AWS SDK v2 sync clients to TestUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${aws.sdkv2.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
             <version>2.2.9</version>

--- a/src/main/java/cloud/localstack/awssdkv2/TestUtils.java
+++ b/src/main/java/cloud/localstack/awssdkv2/TestUtils.java
@@ -1,27 +1,41 @@
 package cloud.localstack.awssdkv2;
 
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
-import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
-import software.amazon.awssdk.utils.*;
-import software.amazon.awssdk.http.*;
-import software.amazon.awssdk.services.cloudwatch.*;
-import software.amazon.awssdk.services.kinesis.*;
-import software.amazon.awssdk.services.sns.*;
-import software.amazon.awssdk.services.sqs.*;
-import software.amazon.awssdk.services.s3.*;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
-import software.amazon.awssdk.services.ssm.*;
-import software.amazon.awssdk.services.iam.*;
-import software.amazon.awssdk.services.qldb.*;
-import software.amazon.awssdk.auth.credentials.*;
-import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
-import software.amazon.awssdk.core.client.builder.SdkAsyncClientBuilder;
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
-
 import cloud.localstack.Localstack;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.builder.SdkAsyncClientBuilder;
+import software.amazon.awssdk.core.client.builder.SdkSyncClientBuilder;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.iam.IamAsyncClient;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.qldb.QldbAsyncClient;
+import software.amazon.awssdk.services.qldb.QldbClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.utils.AttributeMap;
 
-import java.net.*;
+import java.net.URI;
 
 /**
  * Utility methods for AWS SDK v2
@@ -30,53 +44,111 @@ import java.net.*;
 public class TestUtils {
 
     public static KinesisAsyncClient getClientKinesisAsyncV2() {
-        return wrapApiClientV2(KinesisAsyncClient.builder(), Localstack.INSTANCE.getEndpointKinesis()).build();
+        return wrapApiAsyncClientV2(KinesisAsyncClient.builder(), Localstack.INSTANCE.getEndpointKinesis()).build();
+    }
+
+    public static KinesisClient getClientKinesisV2() {
+        return wrapApiSyncClientV2(KinesisClient.builder(), Localstack.INSTANCE.getEndpointKinesis()).build();
     }
 
     public static DynamoDbAsyncClient getClientDyanamoAsyncV2() {
-        return wrapApiClientV2(DynamoDbAsyncClient.builder(), Localstack.INSTANCE.getEndpointDynamoDB()).build();
+        return wrapApiAsyncClientV2(DynamoDbAsyncClient.builder(), Localstack.INSTANCE.getEndpointDynamoDB()).build();
+    }
+
+    public static DynamoDbClient getClientDyanamoV2() {
+        return wrapApiSyncClientV2(DynamoDbClient.builder(), Localstack.INSTANCE.getEndpointDynamoDB()).build();
     }
 
     public static SqsAsyncClient getClientSQSAsyncV2() {
-        return wrapApiClientV2(SqsAsyncClient.builder(), Localstack.INSTANCE.getEndpointSQS()).build();
+        return wrapApiAsyncClientV2(SqsAsyncClient.builder(), Localstack.INSTANCE.getEndpointSQS()).build();
+    }
+
+    public static SqsClient getClientSQSV2() {
+        return wrapApiSyncClientV2(SqsClient.builder(), Localstack.INSTANCE.getEndpointSQS()).build();
     }
 
     public static QldbAsyncClient getClientQLDBAsyncV2() {
-        return wrapApiClientV2(QldbAsyncClient.builder(), Localstack.INSTANCE.getEndpointQLDB()).build();
+        return wrapApiAsyncClientV2(QldbAsyncClient.builder(), Localstack.INSTANCE.getEndpointQLDB()).build();
+    }
+
+    public static QldbClient getClientQLDBV2() {
+        return wrapApiSyncClientV2(QldbClient.builder(), Localstack.INSTANCE.getEndpointQLDB()).build();
     }
 
     public static SnsAsyncClient getClientSNSAsyncV2() {
-        return wrapApiClientV2(SnsAsyncClient.builder(), Localstack.INSTANCE.getEndpointSNS()).build();
+        return wrapApiAsyncClientV2(SnsAsyncClient.builder(), Localstack.INSTANCE.getEndpointSNS()).build();
+    }
+
+    public static SnsClient getClientSNSV2() {
+        return wrapApiSyncClientV2(SnsClient.builder(), Localstack.INSTANCE.getEndpointSNS()).build();
     }
 
     public static SsmAsyncClient getClientSSMAsyncV2() {
-        return wrapApiClientV2(SsmAsyncClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
+        return wrapApiAsyncClientV2(SsmAsyncClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
+    }
+
+    public static SsmClient getClientSSMV2() {
+        return wrapApiSyncClientV2(SsmClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
     }
 
     public static SecretsManagerAsyncClient getClientSecretsManagerAsyncV2() {
-        return wrapApiClientV2(SecretsManagerAsyncClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
+        return wrapApiAsyncClientV2(SecretsManagerAsyncClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
+    }
+
+    public static SecretsManagerClient getClientSecretsManagerV2() {
+        return wrapApiSyncClientV2(SecretsManagerClient.builder(), Localstack.INSTANCE.getEndpointSSM()).build();
     }
 
     public static S3AsyncClient getClientS3AsyncV2() {
-        return wrapApiClientV2(S3AsyncClient.builder(), Localstack.INSTANCE.getEndpointS3()).build();
+        return wrapApiAsyncClientV2(S3AsyncClient.builder(), Localstack.INSTANCE.getEndpointS3()).build();
     }
-    
+
+    public static S3Client getClientS3V2() {
+        return wrapApiSyncClientV2(S3Client.builder(), Localstack.INSTANCE.getEndpointS3()).build();
+    }
+
     public static CloudWatchAsyncClient getClientCloudWatchAsyncV2() {
-        return wrapApiClientV2(CloudWatchAsyncClient.builder(), Localstack.INSTANCE.getEndpointCloudWatch()).build();
+        return wrapApiAsyncClientV2(CloudWatchAsyncClient.builder(), Localstack.INSTANCE.getEndpointCloudWatch()).build();
+    }
+
+    public static CloudWatchClient getClientCloudWatchV2() {
+        return wrapApiSyncClientV2(CloudWatchClient.builder(), Localstack.INSTANCE.getEndpointCloudWatch()).build();
     }
 
     public static LambdaAsyncClient getClientLambdaAsyncV2() {
-        return wrapApiClientV2(LambdaAsyncClient.builder(), Localstack.INSTANCE.getEndpointLambda()).build();
+        return wrapApiAsyncClientV2(LambdaAsyncClient.builder(), Localstack.INSTANCE.getEndpointLambda()).build();
     }
-    
+
+    public static LambdaClient getClientLambdaV2() {
+        return wrapApiSyncClientV2(LambdaClient.builder(), Localstack.INSTANCE.getEndpointLambda()).build();
+    }
+
     public static IamAsyncClient getClientIamAsyncV2() {
-        return wrapApiClientV2(IamAsyncClient.builder(), Localstack.INSTANCE.getEndpointIAM()).build();
+        return wrapApiAsyncClientV2(IamAsyncClient.builder(), Localstack.INSTANCE.getEndpointIAM()).build();
     }
-    
-    public static <T extends SdkAsyncClientBuilder> T wrapApiClientV2(T builder, String endpointURL) {
+
+    public static IamClient getClientIamV2() {
+        return wrapApiSyncClientV2(IamClient.builder(), Localstack.INSTANCE.getEndpointIAM()).build();
+    }
+
+    public static <T extends SdkAsyncClientBuilder> T wrapApiAsyncClientV2(T builder, String endpointURL) {
         try {
             return (T) ((AwsClientBuilder)builder
                 .httpClient(NettyNioAsyncHttpClient.builder().buildWithDefaults(
+                    AttributeMap.builder().put(
+                        SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, java.lang.Boolean.TRUE).build())))
+                .credentialsProvider(getCredentialsV2())
+                .region(Region.of(Localstack.INSTANCE.getDefaultRegion()))
+                .endpointOverride(new URI(endpointURL));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T extends SdkSyncClientBuilder> T wrapApiSyncClientV2(T builder, String endpointURL) {
+        try {
+            return (T) ((AwsClientBuilder)builder
+                .httpClient(ApacheHttpClient.builder().buildWithDefaults(
                     AttributeMap.builder().put(
                         SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, java.lang.Boolean.TRUE).build())))
                 .credentialsProvider(getCredentialsV2())


### PR DESCRIPTION
Adds sync versions of the AWS SDK v2 SyncClients available in TestUtils to address issue #51 
Tests in `BasicFeaturesSDKV2Test` have been extended to test both the async and sync clients.