### PR TITLE
Add docker executable path under homebrew

### DIFF
--- a/src/main/java/cloud/localstack/docker/DockerExe.java
+++ b/src/main/java/cloud/localstack/docker/DockerExe.java
@@ -28,6 +28,7 @@ public class DockerExe {
             "C:/program files/docker/docker/resources/bin/docker.exe",
             "C:/program files/docker/docker/resources/docker.exe",
             "/usr/local/bin/docker",
+            "/opt/homebrew/bin/docker",
             "/usr/bin/docker");
 
     private final String exeLocation;


### PR DESCRIPTION
I'm using the docker binary installed by homebrew with Colima as Docker server/daemon.
The path of this executable is not present in the default list.
