### PR TITLE
Added support for rds with a non default port. Mainly used while runn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,20 @@ Simply add the following dependency to your `pom.xml` file:
 
 You can configure the Docker behaviour using the `@LocalstackDockerProperties` annotation with the following parameters:
 
-| property                    | usage                                                                                                                        | type                         | default value |
-|-----------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------------|---------------|
-| `pullNewImage`              | Determines if a new image is pulled from the docker repo before the tests are run.                                           | boolean                      | `false`         |
-| `services`                  | Determines which services should be run when the localstack starts.                                                          | String[]                     | All           |
-| `imageName`                 | Use a specific image name (organisation/repo) for docker container                                                           | String                       | `localstack/localstack`  |
-| `imageTag`                  | Use a specific image tag for docker container                                                                                | String                       | `latest`        |
-| `portEdge`                  | Port number for the edge service, the main entry point for all API invocations                                               | String                       | `4566`        |
-| `portElasticSearch`         | Port number for the elasticsearch service                                                                                    | String                       | `4571`        |
-| `hostNameResolver`          | Used for determining the host name of the machine running the docker containers so that the containers can be addressed.     | IHostNameResolver            | `localhost`     |
-| `environmentVariableProvider` | Used for injecting environment variables into the container.                                                               | IEnvironmentVariableProvider | Empty Map     |
-| `bindMountProvider`         | Used bind mounting files and directories into the container, useful to run init scripts before using the container.          | IBindMountProvider           | Empty Map     |
-|  `initializationToken`      | Give a regex that will be searched in the logstream of the container, start is complete only when the token is found. Use with bindMountProvider to execute init scripts. | String | Empty String |
-| `useSingleDockerContainer`  | Whether a singleton container should be used by all test classes.                                                            | boolean | `false`     |
+| property                      | usage                                                                                                                                                                     | type                         | default value           |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|-------------------------|
+| `pullNewImage`                | Determines if a new image is pulled from the docker repo before the tests are run.                                                                                        | boolean                      | `false`                 |
+| `services`                    | Determines which services should be run when the localstack starts.                                                                                                       | String[]                     | All                     |
+| `imageName`                   | Use a specific image name (organisation/repo) for docker container                                                                                                        | String                       | `localstack/localstack` |
+| `imageTag`                    | Use a specific image tag for docker container                                                                                                                             | String                       | `latest`                |
+| `portEdge`                    | Port number for the edge service, the main entry point for all API invocations                                                                                            | String                       | `4566`                  |
+| `portElasticSearch`           | Port number for the elasticsearch service                                                                                                                                 | String                       | `4571`                  |
+| `portRDS`                     | Port number for the RDS service                                                                                                                                           | String                       | `4510`                  |
+| `hostNameResolver`            | Used for determining the host name of the machine running the docker containers so that the containers can be addressed.                                                  | IHostNameResolver            | `localhost`             |
+| `environmentVariableProvider` | Used for injecting environment variables into the container.                                                                                                              | IEnvironmentVariableProvider | Empty Map               |
+| `bindMountProvider`           | Used bind mounting files and directories into the container, useful to run init scripts before using the container.                                                       | IBindMountProvider           | Empty Map               |
+| `initializationToken`         | Give a regex that will be searched in the logstream of the container, start is complete only when the token is found. Use with bindMountProvider to execute init scripts. | String | Empty String            |
+| `useSingleDockerContainer`    | Whether a singleton container should be used by all test classes.                                                                                                         | boolean | `false`                 |
 
 For more details, please refer to the README of the main LocalStack repo: https://github.com/localstack/localstack
 

--- a/src/main/java/cloud/localstack/Localstack.java
+++ b/src/main/java/cloud/localstack/Localstack.java
@@ -81,7 +81,7 @@ public class Localstack {
                     dockerConfiguration.isPullNewImage(), dockerConfiguration.isRandomizePorts(),
                     dockerConfiguration.getImageName(), dockerConfiguration.getImageTag(),
                     dockerConfiguration.getPortEdge(), dockerConfiguration.getPortElasticSearch(),
-                    environmentVariables, dockerConfiguration.getPortMappings(),
+                    dockerConfiguration.getPortRDS(), environmentVariables, dockerConfiguration.getPortMappings(),
                     dockerConfiguration.getBindMounts(), dockerConfiguration.getPlatform());
             loadServiceToPortMap();
 

--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -25,6 +25,7 @@ public class Container {
     private static final String LOCALSTACK_TAG = "latest";
     private static final String LOCALSTACK_PORT_EDGE = "4566";
     private static final String LOCALSTACK_PORT_ELASTICSEARCH = "4571";
+    private static final String LOCALSTACK_PORT_RDS = "4510";
 
     private static final int MAX_PORT_CONNECTION_ATTEMPTS = 10;
     private static final int MAX_LOG_COLLECTION_ATTEMPTS = 120;
@@ -51,15 +52,18 @@ public class Container {
      *                       in order to prevent conflicts with other localstack containers running on the same machine
      * @param imageName the name of the image defaults to {@value LOCALSTACK_NAME} if null
      * @param imageTag the tag of the image to pull, defaults to {@value LOCALSTACK_TAG} if null
+     * @param portEdge Edge port
+     * @param portElasticSearch Elasticsearch port
+     * @param portRDS RDS port
      * @param environmentVariables map of environment variables to be passed to the docker container
-     * @param portMappings
+     * @param portMappings All port mappings to be exposed by the container. If null, the default ports will be exposed.
      * @param bindMounts  Docker host to container volume mapping like /host/dir:/container/dir, be aware that the host
      * directory must be an absolute path
      * @param platform target platform for the localstack docker image
      */
     public static Container createLocalstackContainer(
             String externalHostName, boolean pullNewImage, boolean randomizePorts, String imageName, String imageTag, String portEdge,
-            String portElasticSearch, Map<String, String> environmentVariables, Map<Integer, Integer> portMappings,
+            String portElasticSearch, String portRDS, Map<String, String> environmentVariables, Map<Integer, Integer> portMappings,
             Map<String, String> bindMounts, String platform) {
 
         environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
@@ -73,6 +77,7 @@ public class Container {
         String fullPortEdge = (portEdge == null ? LOCALSTACK_PORT_EDGE : portEdge) + ":" + LOCALSTACK_PORT_EDGE;
         String fullPortElasticSearch = (portElasticSearch == null ? LOCALSTACK_PORT_ELASTICSEARCH : portElasticSearch)
             + ":" + LOCALSTACK_PORT_ELASTICSEARCH;
+        String fullPortRDS = (portRDS == null ? LOCALSTACK_PORT_RDS : portRDS) + ":" + LOCALSTACK_PORT_RDS;
 
         if(pullNewImage || !imageExists) {
             LOG.info(String.format("Pulling image %s", fullImageName));
@@ -82,6 +87,7 @@ public class Container {
         RunCommand runCommand = new RunCommand(imageNameOrDefault, imageTag)
             .withExposedPorts(fullPortEdge, randomizePorts)
             .withExposedPorts(fullPortElasticSearch, randomizePorts)
+            .withExposedPorts(fullPortRDS, randomizePorts)
             .withEnvironmentVariable(LOCALSTACK_EXTERNAL_HOSTNAME, externalHostName)
             .withEnvironmentVariable(ENV_DEBUG, ENV_DEBUG_DEFAULT)
             .withEnvironmentVariable(ENV_USE_SSL, Localstack.useSSL() ? "1" : "0")

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
@@ -42,6 +42,7 @@ public class LocalstackDockerAnnotationProcessor {
             .imageTag(StringUtils.isEmpty(properties.imageTag()) ? null : properties.imageTag())
             .portEdge(getEnvOrDefault("LOCALSTACK_EDGE_PORT", properties.portEdge()))
             .portElasticSearch(getEnvOrDefault("LOCALSTACK_ELASTICSEARCH_PORT", properties.portElasticSearch()))
+            .portRDS(getEnvOrDefault("LOCALSTACK_RDS_PORT", properties.portRDS()))
             .useSingleDockerContainer(properties.useSingleDockerContainer())
             .platform(StringUtils.isEmpty(properties.platform()) ? null : properties.platform())
             .build();

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -36,6 +36,9 @@ public class LocalstackDockerConfiguration {
     private final String portElasticSearch = "4571";
 
     @Builder.Default
+    private final String portRDS = "4510";
+
+    @Builder.Default
     private final String externalHostName = "localhost";
 
     @Builder.Default

--- a/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -83,6 +83,12 @@ public @interface LocalstackDockerProperties {
     String portElasticSearch() default "4571";
 
     /**
+     * Port number for the RDS service. Alternatively, use the LOCALSTACK_RDS_PORT environment
+     * variable.
+     */
+    String portRDS() default "4510";
+
+    /**
      * Determines if the singleton container should be used by all test classes
      */
     boolean useSingleDockerContainer() default false;

--- a/src/test/java/cloud/localstack/awssdkv1/docker/ContainerTest.java
+++ b/src/test/java/cloud/localstack/awssdkv1/docker/ContainerTest.java
@@ -32,7 +32,7 @@ public class ContainerTest {
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
         Container localStackContainer = Container.createLocalstackContainer(
-                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, environmentVariables, null, null, null);
+                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null,null, environmentVariables, null, null, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -60,7 +60,7 @@ public class ContainerTest {
 
         String customImageName = "localstack/localstack-full";
         Container localStackContainer = Container.createLocalstackContainer(
-                EXTERNAL_HOST_NAME, pullNewImage, false, customImageName, null, null, null, null, null, null, null);
+                EXTERNAL_HOST_NAME, pullNewImage, false, customImageName, null, null, null,null, null, null, null, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -80,7 +80,7 @@ public class ContainerTest {
     public void createLocalstackContainerWithScriptMounted() {
 
         Container localStackContainer = Container.createLocalstackContainer(
-                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null,
+                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null,null, null, null, null,
                 Collections.singletonMap(testFile("echo testmarker"), Localstack.INIT_SCRIPTS_PATH + "/test.sh"), null);
 
         try {
@@ -109,13 +109,14 @@ public class ContainerTest {
     @Test
     public void createLocalstackContainerWithCustomPorts() throws Exception {
         Container localStackContainer = Container.createLocalstackContainer(
-                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, "45660", "45710", null, null, null, null);
+                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, "45660", "45710", "45100", null, null, null, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
 
             assertEquals(45660, localStackContainer.getExternalPortFor(4566));
             assertEquals(45710, localStackContainer.getExternalPortFor(4571));
+            assertEquals(45100, localStackContainer.getExternalPortFor(4510));
         }
         finally {
             localStackContainer.stop();
@@ -126,13 +127,14 @@ public class ContainerTest {
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
         Container localStackContainer = Container.createLocalstackContainer(
-                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, ":4566", ":4571", null, null, null, null);
+                EXTERNAL_HOST_NAME, pullNewImage, false, null, null, ":4566", ":4571", ":4510",null, null, null, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
 
             assertNotEquals(4566, localStackContainer.getExternalPortFor(4566));
             assertNotEquals(4571, localStackContainer.getExternalPortFor(4571));
+            assertNotEquals(4510, localStackContainer.getExternalPortFor(4510));
         }
         finally {
             localStackContainer.stop();

--- a/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
+++ b/src/test/java/cloud/localstack/deprecated/PortBindingTest.java
@@ -35,7 +35,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -53,7 +53,7 @@ public class PortBindingTest {
     @Test
     public void createLocalstackContainerWithStaticPorts() throws Exception {
         Container container = Container.createLocalstackContainer(
-            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null, null, null);
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null, null, null, null, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);


### PR DESCRIPTION
…ing tests with more than one Localstack container on the same machine, to avoid port allocation issues.