### PR TITLE
Fix check if an event should be read as SQS event

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.2.21</version>
+    <version>0.2.22</version>
 </dependency>
 ```
 
@@ -108,6 +108,7 @@ make build
 
 ## Change Log
 
+* v0.2.22: Fix sqs event mapping for new event format, some test fixes
 * v0.2.21: Bump version of AWS SDK v1; add AWS SDK v2 sync clients to TestUtils; add docker executable path under homebrew
 * v0.2.20: Fix extracting container logs for LocalStack startup check
 * v0.2.19: Bump version of log4j to 2.17.0 to fix further vulnerabilities related to recent CVE

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.21</version>
+    <version>0.2.22</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -29,7 +29,13 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -29,12 +29,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -104,7 +99,7 @@ public class LambdaExecutor {
 				inputObject = DDBEventParser.parse(records);
 			} else if (records.stream().anyMatch(record -> record.containsKey("s3"))) {
 				inputObject = S3EventParser.parse(records);
-			} else if (records.stream().anyMatch(record -> record.containsKey("sqs"))) {
+			} else if (records.stream().anyMatch(record -> Objects.equals(record.get("eventSource"), "aws:sqs"))) {
 				inputObject = reader.readValue(fileContent, SQSEvent.class);
 			}
 		}


### PR DESCRIPTION
## Motivation
With localstack/localstack#6603, the (incorrect) attribute "sqs" was removed from the event layout.
However, it seems this broke the javalibs, as they assumed that attribute to be present for the detection of a sqs event.

This PR will correct the incorrect assumption on the java util side, to allow SQSEvents to be properly created again.

Addresses localstack/localstack#6995 .
This only affects the local provider, but I fixed it regardless as it is a regression.

The whole logic isn't valid, we should inspect the lambda handler and check its type to use it, but implementing that (which is already implemented in the lambda java ric anyway) seems unnecessary if the local executor is deprecated anyway.

## Changes

* Use the (acutally present, also in AWS) `eventSource` attribute of a record to check if it is an sqs event, instead of the incorrect sqs key.
* Update to 0.2.22