### PR TITLE
fix S3 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.2.22</version>
+    <version>0.2.23</version>
 </dependency>
 ```
 
@@ -112,6 +112,7 @@ To publish a release of the library, the "Maven Release" Github Action can be ma
 
 ## Change Log
 
+* v0.2.23: Fix S3 endpoints to be compatible with LocalStack v2
 * v0.2.22: Fix sqs event mapping for new event format, some test fixes
 * v0.2.21: Bump version of AWS SDK v1; add AWS SDK v2 sync clients to TestUtils; add docker executable path under homebrew
 * v0.2.20: Fix extracting container logs for LocalStack startup check

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.22</version>
+    <version>0.2.23</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/src/main/java/cloud/localstack/Constants.java
+++ b/src/main/java/cloud/localstack/Constants.java
@@ -8,6 +8,8 @@ public class Constants {
 
     public static final String LOCALHOST_DOMAIN_NAME = "localhost.localstack.cloud";
 
+    public static final String S3_LOCALHOST_DOMAIN_NAME = "s3.localhost.localstack.cloud";
+
     public static final String DEFAULT_AWS_ACCOUNT_ID = "000000000000";
 
     public static final String ENV_LOCALSTACK_API_KEY = "LOCALSTACK_API_KEY";

--- a/src/main/java/cloud/localstack/Localstack.java
+++ b/src/main/java/cloud/localstack/Localstack.java
@@ -176,7 +176,7 @@ public class Localstack {
          * <bucket-name>.localhost, but that name cannot be resolved (unless hardcoded
          * in /etc/hosts)
          */
-        s3Endpoint = s3Endpoint.replace("localhost", Constants.LOCALHOST_DOMAIN_NAME);
+        s3Endpoint = s3Endpoint.replace("localhost", Constants.S3_LOCALHOST_DOMAIN_NAME);
         return s3Endpoint;
     }
 

--- a/src/main/java/cloud/localstack/deprecated/Localstack.java
+++ b/src/main/java/cloud/localstack/deprecated/Localstack.java
@@ -131,7 +131,7 @@ public class Localstack {
          * which by default would result in <bucket-name>.localhost, but that name cannot be resolved
          * (unless hardcoded in /etc/hosts)
          */
-        s3Endpoint = s3Endpoint.replace("localhost", Constants.LOCALHOST_DOMAIN_NAME);
+        s3Endpoint = s3Endpoint.replace("localhost", Constants.S3_LOCALHOST_DOMAIN_NAME);
         return s3Endpoint;
     }
 


### PR DESCRIPTION
Fixing the S3 endpoints to use `s3.localhost.localstack.cloud:4566` instead of `localhost.localstack.cloud:4566` which doesn't support virtual host addressing

this should address https://github.com/localstack/localstack/issues/8018