### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -38,7 +38,7 @@ public class Container {
     private static final String ENV_DEBUG_DEFAULT = "1";
     public static final String LOCALSTACK_EXTERNAL_HOSTNAME = "HOSTNAME_EXTERNAL";
 
-    private static final String DEFAULT_CONTAINER_ID = "localstack_main";
+    private static final String DEFAULT_CONTAINER_ID = "localstack-main";
 
     private final String containerId;
     private final List<PortMapping> ports;


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
