### PR TITLE
fix: Use `localstack/localstack-pro` by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Pull Docker containers
         run: |
           set -e
-          nohup docker pull localstack/localstack-ext > /dev/null &
+          nohup docker pull localstack/localstack-pro > /dev/null &
       - name: Compile Tests
         run: |
           set -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "8"
-      - name: Pull Docker containers
-        run: |
-          set -e
-          nohup docker pull localstack/localstack-pro > /dev/null &
       - name: Compile Tests
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.2.23</version>
+    <version>0.2.24</version>
 </dependency>
 ```
 
@@ -114,6 +114,7 @@ To publish a release of the library, the "Maven Release" Github Action can be ma
 
 ## Change Log
 
+* v0.2.24: Make localstack/localstack-pro the default image
 * v0.2.23: Fix S3 endpoints to be compatible with LocalStack v2
 * v0.2.22: Fix sqs event mapping for new event format, some test fixes
 * v0.2.21: Bump version of AWS SDK v1; add AWS SDK v2 sync clients to TestUtils; add docker executable path under homebrew

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.2.24</version>
+    <version>0.3.0</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ To publish a release of the library, the "Maven Release" Github Action can be ma
 
 ## Change Log
 
-* v0.2.24: Make localstack/localstack-pro the default image
+* v0.3.0: Makes localstack/localstack-pro the default image. For more information see: https://blog.localstack.cloud/localstack-single-image-next-steps/
 * v0.2.23: Fix S3 endpoints to be compatible with LocalStack v2
 * v0.2.22: Fix sqs event mapping for new event format, some test fixes
 * v0.2.21: Bump version of AWS SDK v1; add AWS SDK v2 sync clients to TestUtils; add docker executable path under homebrew

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.23</version>
+    <version>0.2.24</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.24</version>
+    <version>0.3.0</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -67,7 +67,7 @@ public class Container {
         bindMounts = bindMounts == null ? Collections.emptyMap() : bindMounts;
         portMappings = portMappings == null ? Collections.emptyMap() : portMappings;
 
-        String imageNameOrDefault = !StringUtils.isEmpty(imageName) ? imageName : LOCALSTACK_PRO_IMAGE
+        String imageNameOrDefault = !StringUtils.isEmpty(imageName) ? imageName : LOCALSTACK_PRO_IMAGE;
         String fullImageName = imageNameOrDefault + ":" + (imageTag == null ? LOCALSTACK_IMAGE_TAG : imageTag);
         boolean imageExists = new ListImagesCommand().execute().contains(fullImageName);
 

--- a/src/main/java/cloud/localstack/docker/Container.java
+++ b/src/main/java/cloud/localstack/docker/Container.java
@@ -22,7 +22,6 @@ public class Container {
 
     private static final Logger LOG = Logger.getLogger(Container.class.getName());
 
-    private static final String LOCALSTACK_IMAGE = "localstack/localstack";
     private static final String LOCALSTACK_PRO_IMAGE = "localstack/localstack-pro";
     private static final String LOCALSTACK_IMAGE_TAG = "latest";
     private static final String LOCALSTACK_PORT_EDGE = "4566";
@@ -51,7 +50,7 @@ public class Container {
      * @param pullNewImage determines if docker pull should be run to update to the latest image of the container
      * @param randomizePorts determines if the container should expose the default local stack ports or if it should expose randomized ports
      *                       in order to prevent conflicts with other localstack containers running on the same machine
-     * @param imageName the name of the image defaults to {@value LOCALSTACK_IMAGE} if null
+     * @param imageName the name of the image defaults to {@value LOCALSTACK_PRO_IMAGE} if null
      * @param imageTag the tag of the image to pull, defaults to {@value LOCALSTACK_IMAGE_TAG} if null
      * @param environmentVariables map of environment variables to be passed to the docker container
      * @param portMappings port mappings
@@ -68,11 +67,7 @@ public class Container {
         bindMounts = bindMounts == null ? Collections.emptyMap() : bindMounts;
         portMappings = portMappings == null ? Collections.emptyMap() : portMappings;
 
-        String imageNameOrDefault = imageName;
-        if (StringUtils.isEmpty(imageName)) {
-            String apiKeyEnv = System.getenv(Constants.ENV_LOCALSTACK_API_KEY);
-            imageNameOrDefault = !StringUtils.isEmpty(apiKeyEnv) ? LOCALSTACK_PRO_IMAGE : LOCALSTACK_IMAGE;
-        }
+        String imageNameOrDefault = !StringUtils.isEmpty(imageName) ? imageName : LOCALSTACK_PRO_IMAGE
         String fullImageName = imageNameOrDefault + ":" + (imageTag == null ? LOCALSTACK_IMAGE_TAG : imageTag);
         boolean imageExists = new ListImagesCommand().execute().contains(fullImageName);
 

--- a/src/test/java/cloud/localstack/awssdkv1/testcontainers/TestContainersSqsTest.java
+++ b/src/test/java/cloud/localstack/awssdkv1/testcontainers/TestContainersSqsTest.java
@@ -36,7 +36,7 @@ import com.amazonaws.services.sqs.model.SendMessageResult;
  */
 public class TestContainersSqsTest {
 
-    private static final String DOCKER_IMAGE_NAME = "localstack/localstack:latest";
+    private static final String DOCKER_IMAGE_NAME = "localstack/localstack-pro:latest";
 
     private AmazonSQS amazonSQS;
 


### PR DESCRIPTION
## Changes
- Updates the code to no longer use `localstack/localstack` and opt to use `localstack/localstack-pro` instead. The prior can still be used if specified.
- The workflow doesn't work on latest due to an issue with the Docker SDK which makes me believe it has been broken for quite a while since our testing workflow usually tests against Pro by default.
  - Since it's not been raised it is likely an issue specific to our test set up.