### PR TITLE
Deprecate `localstack-java-utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![CI](https://github.com/localstack/localstack-java-utils/actions/workflows/build.yml/badge.svg)](https://github.com/localstack/localstack-java-utils/actions/workflows/build.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/cloud.localstack/localstack-utils)](https://mvnrepository.com/artifact/cloud.localstack/localstack-utils)
 
-⚠️ Note: This repo is not currently very actively maintained. Please consider using the [Testcontainers LocalStack Java module](https://java.testcontainers.org/modules/localstack/) as a potential alternative.
+> [!IMPORTANT]  
+> This utility is officially deprecated and official support is no longer provided. Please consider using the [Testcontainers LocalStack Java module](https://java.testcontainers.org/modules/localstack/) as a potential alternative.
 
 # LocalStack Java Utils
 


### PR DESCRIPTION
## Changes
- Update README.md to contain deprecation message as no further releases will be made from this repository.
- Following this PR the repository will be archived!
<img width="783" height="157" alt="image" src="https://github.com/user-attachments/assets/e5defc32-59cb-46b6-9314-3df9ff0afd5e" />

